### PR TITLE
Allow big mobile id entries. fix downloadable id

### DIFF
--- a/app/Http/Controllers/DownloadsController.php
+++ b/app/Http/Controllers/DownloadsController.php
@@ -204,6 +204,7 @@ class DownloadsController extends Controller
             'Custom Identifier',
             'Observation Category',
             'Latin Name',
+            'Submitter',
             'Latitude',
             'Longitude',
             'Location Accuracy',
@@ -230,10 +231,12 @@ class DownloadsController extends Controller
         $latitude = $observation->fuzzy_coords['latitude'];
         $longitude = $observation->fuzzy_coords['longitude'];
         $location_accuracy = 'Fuzzy: within 8 kilometers';
+        $user_name = $user->is_anonymous ? 'Anonymous' : $user->name;
         if ($this->hasPrivilegedPermissions($user, $observation)) {
             $latitude = $observation->latitude;
             $longitude = $observation->longitude;
             $location_accuracy = "Exact: within {$observation->location_accuracy} meters";
+            $user_name = $user->name;
         } elseif ($observation->isPrivate) {
             // Ignore the observation if it is private and the user
             // does not have privileged permissions to access it
@@ -246,10 +249,11 @@ class DownloadsController extends Controller
         }
 
         $line = [
-            "{$observation->id}-{$observation->mobile_id}",
+            $observation->mobile_id,
             $observation->custom_id ?: 'NULL',
             $observation->observation_category,
             "{$observation->latinName->genus} {$observation->latinName->species}",
+            $user_name,
             $latitude,
             $longitude,
             $location_accuracy,

--- a/database/migrations/2018_08_09_144037_change_mobile_id_to_big_int_in_observations_table.php
+++ b/database/migrations/2018_08_09_144037_change_mobile_id_to_big_int_in_observations_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeMobileIdToBigIntInObservationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('observations', function (Blueprint $table) {
+            $table->bigInteger('mobile_id')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('observations', function (Blueprint $table) {
+            $table->integer('mobile_id')->default(0)->change();
+        });
+    }
+}


### PR DESCRIPTION
- Fixes downloadables id field by providing only the mobile_id that's normally visible to the user
- Allow mobile_id to be a large 10 digit number
- Add user names for non-anonymous users in downloadables