### PR TITLE
Replicate share code in API folder

### DIFF
--- a/app/Http/Controllers/Api/v1/ShareTokensController.php
+++ b/app/Http/Controllers/Api/v1/ShareTokensController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\v1;
 
+use App\Http\Controllers\Controller;
 use App\Observation;
 use App\ShareToken;
 use App\Http\Controllers\Traits\Responds;

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,6 +34,8 @@ Route::group([
     // Actions
     Route::get('/actions', 'ActionsController@index');
     Route::post('/action/completed/{action}', 'ActionsController@completed');
+
+    Route::get('/share/observation/{id}', 'ShareTokensController@share');
 });
 
 // Methods that do not require an api_key


### PR DESCRIPTION
This allows sharing from the mobile app. @jwest60 you forgot to push your code for this part so I simply replicated it so that we can publish the app soon.