### PR TITLE
Shows a user's pending invitations on the Groups page

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -185,6 +185,7 @@ class GroupsController extends Controller
             'owner' => $group->users->where('id', $group->user_id)->first(),
             'is_owner' => $user->id === $group->user_id,
             'is_sharing' => $is_sharing,
+            'is_private' => $group->is_private,
         ]);
     }
 

--- a/app/Http/Controllers/Traits/InvitesToGroups.php
+++ b/app/Http/Controllers/Traits/InvitesToGroups.php
@@ -53,7 +53,7 @@ trait InvitesToGroups
             'email' => $request->email,
             'status' => 0,
             'token' => $rand,
-            'expires_at' => Carbon::now()->addDay(),
+            'expires_at' => Carbon::now()->addYear(),
         ]);
     }
 

--- a/app/Invite.php
+++ b/app/Invite.php
@@ -40,4 +40,9 @@ class Invite extends Model
     {
         return $this->belongsTo('App\Group');
     }
+
+    public function invitee()
+    {
+        return $this->belongsTo('App\User', 'email', 'email');
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -48,6 +48,7 @@ class RouteServiceProvider extends ServiceProvider
             'filters',
             'groups',
             'group/([0-9]+)',
+            'invitations',
             'collections',
             'observations',
             'curate',

--- a/app/User.php
+++ b/app/User.php
@@ -295,4 +295,9 @@ class User extends Authenticatable
         return $this->belongsToMany(SubscriptionTopic::class, 'subscription_topics_user', 'user_id',
             'subscription_topic_id');
     }
+
+    public function invites()
+    {
+        return Invite::where(['email' => $this->email, 'status' => 0])->get();
+    }
 }

--- a/resources/assets/js/components/Group.jsx
+++ b/resources/assets/js/components/Group.jsx
@@ -17,6 +17,8 @@ export default class Group extends Component {
   constructor(props) {
     super(props)
 
+    console.log(this.props)
+
     this.state = {
       id                : 0,
       isPrivate         : false,
@@ -76,7 +78,8 @@ export default class Group extends Component {
         isOwner  : data.is_owner,
         leader   : data.owner,
         isSharing: data.is_sharing,
-        newName  : data.name
+        newName  : data.name,
+        isPrivate: data.is_private
       })
 
       document.title = `${data.name} - TreeSnap`
@@ -657,6 +660,8 @@ export default class Group extends Component {
   }
 
   _renderPrivacyModal() {
+    console.log('private = ' + this.state.isPrivate)
+
     return (
       <div>
         <div className="field">
@@ -677,7 +682,7 @@ export default class Group extends Component {
         {this.state.isOwner ? <div className="field mb-2">
           <label className="label">Discoverability</label>
           <span className="select">
-            <select value={this.state.isPrivate}
+            <select value={this.state.isPrivate === false ? 0 : 1}
                     onChange={({target}) => this.toggleDiscoverability(parseInt(target.value))}>
               <option value={1}>Users must be invited to join</option>
               <option value={0}>Allow anyone to find this group and apply to join</option>

--- a/resources/assets/js/components/Groups.jsx
+++ b/resources/assets/js/components/Groups.jsx
@@ -133,7 +133,6 @@ export default class Groups extends Component {
         <tr>
           <th>Group Name</th>
           <th>Group Owner</th>
-          {/*<th>Invited By</th>*/}
           <th>Invited By</th>
           <th></th>
         </tr>
@@ -175,10 +174,8 @@ export default class Groups extends Component {
     })
 
     axios.post(`/web/invitations/accept`, {
-      // params: {
       invite: invitation.id,
         _t: invitation.token
-      // }
     }).then(async () => {
       Notify.push(`You have joined ${invitation.group.name} successfully.`)
       await this.loadGroupsAndInvitations()

--- a/resources/assets/js/components/Groups.jsx
+++ b/resources/assets/js/components/Groups.jsx
@@ -12,17 +12,19 @@ export default class Groups extends Component {
     super(props)
 
     this.state = {
-      name     : '',
-      share    : false,
+      name: '',
+      share: false,
       isPrivate: 0,
-      errors   : {
-        share    : [],
-        name     : [],
+      errors: {
+        share: [],
+        name: [],
         isPrivate: []
       },
-      groups   : [],
-      success  : false,
-      loading  : false
+      groups: [],
+      invitations: [],
+      acceptingInvitation: -1,
+      success: false,
+      loading: true
     }
 
     document.title = 'Groups - TreeSnap'
@@ -31,18 +33,33 @@ export default class Groups extends Component {
   /**
    * Get groups from server.
    */
-  componentDidMount() {
+  async componentDidMount() {
+    await this.loadGroupsAndInvitations()
+  }
+
+  async loadGroupsAndInvitations() {
     this.setState({loading: true})
-    axios.get('/web/groups').then(response => {
-      let data = response.data.data
+    try {
+      // Make first two requests
+      let response = await Promise.all([
+        axios.get('/web/groups'),
+        axios.get('/web/invitations')
+      ]);
+
+      let groups = response[0].data.data
+      let invitations = response[1].data.data
+
+      // Update state once with all 3 responses
       this.setState({
-        groups : data,
-        loading: false
-      })
-    }).catch(error => {
+        groups: groups,
+        invitations: invitations,
+        loading: false,
+        acceptingInvitation: -1
+      });
+    } catch (error) {
       console.log(error)
       this.setState({loading: false})
-    })
+    }
   }
 
   /**
@@ -56,7 +73,8 @@ export default class Groups extends Component {
       return (
         <div>
           <p>There are no available groups yet. You can create a group using the form below.</p>
-          <p>If someone else invites you to join their group, the group will show up here once you accept the invitation.</p>
+          <p>If someone else invites you to join their group, the group will show up here once you accept the
+            invitation.</p>
         </div>
       )
     }
@@ -93,6 +111,92 @@ export default class Groups extends Component {
         </tbody>
       </table>
     )
+  }
+
+  /**
+   * Renders invitations table.
+   * @returns {JSX.Element}
+   * @private
+   */
+  _renderInvitationsTable() {
+    if (this.state.invitations.length === 0) {
+      return (
+        <div>
+          <p>You have no pending invitations.</p>
+        </div>
+      )
+    }
+
+    return (
+      <table className="table is-striped mb-none" id="groups-table">
+        <thead>
+        <tr>
+          <th>Group Name</th>
+          <th>Group Owner</th>
+          {/*<th>Invited By</th>*/}
+          <th>Invited By</th>
+          <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {this.state.invitations.map((invitation, index) => {
+          return (
+            <tr key={index}>
+              <td>
+                {invitation.group.name}
+              </td>
+              <td>{invitation.group.owner.name}</td>
+              <td>{invitation.user.name}</td>
+              <td className="has-text-right">
+                <button type="button"
+                        className={`button is-primary is-outlined ${this.state.loading ? ' disabled' : ''}`}
+                        disabled={this.state.loading && this.state.acceptingInvitation !== invitation.group.id}
+                        onClick={() => this.acceptInvite(invitation)}>
+                  {'Accept Invite'}
+                </button>
+              </td>
+            </tr>
+          )
+        })}
+        </tbody>
+      </table>
+    )
+  }
+
+  acceptInvite(invitation) {
+    // Prevent multiple requests
+    if (this.state.acceptingInvitation !== -1) {
+      return
+    }
+
+    this.setState({
+      acceptingInvitation: invitation.id,
+      loading: true
+    })
+
+    axios.post(`/web/invitations/accept`, {
+      // params: {
+      invite: invitation.id,
+        _t: invitation.token
+      // }
+    }).then(async () => {
+      Notify.push(`You have joined ${invitation.group.name} successfully.`)
+      await this.loadGroupsAndInvitations()
+    }).catch(error => {
+      this.setState({
+        acceptingInvitation: -1,
+        loading: false
+      })
+
+      if (!error.response) {
+        Notify.push('Network error! Please try again later', 'danger')
+        return
+      }
+
+      let response = error.response
+
+      console.error(response)
+    })
   }
 
   /**
@@ -181,19 +285,19 @@ export default class Groups extends Component {
   submit(e) {
     e.preventDefault()
     axios.post('/web/groups', {
-      name      : this.state.name,
-      share     : this.state.share,
+      name: this.state.name,
+      share: this.state.share,
       is_private: this.state.isPrivate === 1
     }).then(response => {
-      let data   = response.data.data
+      let data = response.data.data
       let groups = this.state.groups
       groups.push(data)
       this.setState({
-        name  : '',
+        name: '',
         groups,
         errors: {
-          name     : [],
-          share    : [],
+          name: [],
+          share: [],
           isPrivate: []
         }
       })
@@ -204,8 +308,8 @@ export default class Groups extends Component {
         let errors = error.response.data
         this.setState({
           errors: {
-            name     : errors.name || [],
-            share    : errors.share || [],
+            name: errors.name || [],
+            share: errors.share || [],
             isPrivate: errors.is_private || []
           }
         })
@@ -220,6 +324,8 @@ export default class Groups extends Component {
         <div className="box">
           <h4 className="title is-4">Groups</h4>
           {this._renderGroupsTable()}
+          <h4 className='title is-4 mt-2'>Invitations</h4>
+          {this._renderInvitationsTable()}
         </div>
 
         <div className="columns is-multiline">

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,7 +50,7 @@ Route::get('/web/observation/{id}', 'ObservationsController@show');
 // Pre-fetched observation view to support FB open graph and twitter cards
 Route::get('/observation/{id}', 'ObservationsController@showPreFetch');
 
-// Mapf
+// Map
 Route::get('/web/map', 'MapController@index');
 Route::get('/web/map/count', 'MapController@countObservations');
 Route::get('/web/map/{observation}', 'MapController@showObservation');

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,7 +50,7 @@ Route::get('/web/observation/{id}', 'ObservationsController@show');
 // Pre-fetched observation view to support FB open graph and twitter cards
 Route::get('/observation/{id}', 'ObservationsController@showPreFetch');
 
-// Map
+// Mapf
 Route::get('/web/map', 'MapController@index');
 Route::get('/web/map/count', 'MapController@countObservations');
 Route::get('/web/map/{observation}', 'MapController@showObservation');
@@ -162,9 +162,11 @@ Route::group(['middleware' => ['auth']], function () {
     Route::delete('/web/note/{id}', 'NotesController@delete');
 
     // Invitations
+    Route::get('/web/invitations', 'InvitesController@index');
     Route::get('/web/invites/{group_id}', 'InvitesController@showPendingInvitations');
     Route::post('/web/invite', 'InvitesController@newInvitation');
     Route::post('/invitations/accept/authenticated/{id}', 'InvitesController@acceptAuthenticated');
+    Route::post('web/invitations/accept', 'InvitesController@acceptThroughWeb');
 
     // Unsubscribe
     Route::get('/services/unsubscribe/filter/{filter}', 'SubscriptionsController@unsubscribeFilter');


### PR DESCRIPTION
There seems to be an issue with the server not sending emails when someone is invited to a group. This branch allows users to view and accept all pending invitations. This probably should've been in the original design, but for now it will allow the groups feature to remain functional while I dig into the email issue.

Also resolves a bug I discovered regarding inconsistency of a group being public/private.

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/49210178-b168-452b-bd55-033aa01820a1">
